### PR TITLE
feat: SSE 연결 전송시 토큰 포함

### DIFF
--- a/src/components/SSEManager.js
+++ b/src/components/SSEManager.js
@@ -16,6 +16,7 @@ const SSEManager = () => {
 
   // 항상 useState를 호출
   const [storeId, setStoreId] = useState(null);
+  const [token, setToken] = useState(null);
 
   useEffect(() => {
     // 로그인 페이지면 SSE 로직 실행하지 않음
@@ -36,6 +37,7 @@ const SSEManager = () => {
         return;
       }
       setStoreId(decoded.storeId);
+      setToken(accessToken);
       console.log('SSEManager: JWT에서 추출한 storeId:', decoded.storeId);
     } catch (error) {
       console.error('SSEManager: JWT 디코딩 실패:', error);
@@ -59,8 +61,8 @@ const SSEManager = () => {
     [toast, addNotification, isLoginPage],
   );
 
-  // storeId가 null이면 useSSE 내부에서 아무 작업도 하지 않도록 처리합니다.
-  useSSE(storeId, handleNewNotification);
+  // storeId, token 모두 준비되어야 SSE 연결을 시도합니다.
+  useSSE(storeId, token, handleNewNotification);
 
   return null;
 };

--- a/src/hooks/useSSE.js
+++ b/src/hooks/useSSE.js
@@ -1,18 +1,20 @@
 // src/hooks/useSSE.js
 import { useEffect } from 'react';
 
-const useSSE = (storeId, onNewNotification) => {
+const useSSE = (storeId, token, onNewNotification) => {
   useEffect(() => {
-    if (!storeId) {
-      console.warn('❌ storeId가 없음, SSE 실행 안됨');
+    if (!storeId || !token) {
+      console.warn('❌ storeId 또는 token이 없음, SSE 실행 안됨');
       return;
     }
 
     console.log(`✅ SSE 실행됨, storeId: ${storeId}`);
+    //배포시 서버 수정 필요
     const BASE_URL = 'http://localhost:8080';
-    const eventSource = new EventSource(
-      `${BASE_URL}/notifications/subscribe/${storeId}`,
-    );
+    const eventSourceUrl = `${BASE_URL}/notifications/subscribe/${storeId}?token=${encodeURIComponent(
+      token,
+    )}`;
+    const eventSource = new EventSource(eventSourceUrl);
 
     eventSource.addEventListener('Promotion', (event) => {
       console.log('📢 Promotion 이벤트 수신:', event);
@@ -32,8 +34,6 @@ const useSSE = (storeId, onNewNotification) => {
           ...notification,
         };
 
-        // ❌ 기존: onNewNotification((prev) => [notificationWithId, ...prev]);
-        // ⭕ 수정: 알림 "객체"만 콜백으로 넘겨줌
         onNewNotification(notificationWithId);
       } catch (error) {
         console.error('❌ 알림 데이터 파싱 오류:', error);
@@ -53,7 +53,7 @@ const useSSE = (storeId, onNewNotification) => {
       console.log('❌ SSE 연결 해제');
       eventSource.close();
     };
-  }, [storeId, onNewNotification]);
+  }, [storeId, token, onNewNotification]);
 };
 
 export default useSSE;


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #39 

## 📍주요 변경 사항
> EventSource 기반으로 SSE 연결 API 요청시 커스텀 헤더를 추가할 수 없습니다
따라서 요청시 역할 검증을 진행하지 않고,storeId와 토큰 정보를 함께 넘겨 토큰을 서버에서 파싱하여 역할을 검증합니다.

## 🎸기타
> 
